### PR TITLE
Fix mock frame props

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,7 +14,10 @@ const mockRepos = {
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ArtifactFrame mockRepos={mockRepos} mockFrameProps={{ access: [] }}>
+    <ArtifactFrame
+      mockRepos={mockRepos}
+      mockFrameProps={{ expandedAccess: [] }}
+    >
       <ArtifactSyncer>
         <App />
       </ArtifactSyncer>


### PR DESCRIPTION
## Summary
- ensure `mockFrameProps` uses `expandedAccess` key

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_684f81e5a610832ba3c1a35edba3749a