### PR TITLE
Fix repo tree display and selection

### DIFF
--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -1,14 +1,15 @@
 import { FolderGit2 } from 'lucide-react'
-import { RepoScope } from '@artifact/client/api'
+import type { RepoListing } from './RepositoryTree'
 
-export default function RepositoryCard({ repo }: { repo: RepoScope }) {
+export default function RepositoryCard({ repo }: { repo: RepoListing }) {
   return (
     <div className="bg-white border border-gray-200 rounded-lg p-4 mb-2">
       <div className="flex items-center">
         <FolderGit2 className="mr-2" size={18} />
-        <h3 className="font-medium text-blue-600">{repo.repo}</h3>
+        <h3 className="font-medium text-blue-600">{repo.name}</h3>
       </div>
-      <p className="text-xs text-gray-500 mt-1">Repository DID: {repo.did}</p>
+      <p className="text-xs text-gray-500 mt-1">Repo ID: {repo.scope.repo}</p>
+      <p className="text-xs text-gray-500">DID: {repo.scope.did}</p>
     </div>
   )
 }

--- a/src/components/RepositoryTree.tsx
+++ b/src/components/RepositoryTree.tsx
@@ -1,11 +1,13 @@
-import React, { useState } from 'react'
-import { ChevronDown, ChevronRight, FolderGit2, Home, Link } from 'lucide-react'
+import React from 'react'
+import { FolderGit2, Home, Link } from 'lucide-react'
 import { useTree, useScope } from '@artifact/client/hooks'
 import { ArtifactSyncer } from '@artifact/client/react'
 import { isRepoScope, RepoScope } from '@artifact/client/api'
 
+export type RepoListing = { name: string; scope: RepoScope }
+
 export type RepositoryTreeProps = {
-  onSelect?: (scope: RepoScope) => void
+  onSelect?: (repo: RepoListing) => void
 }
 
 const RepositoryTreeRoot: React.FC<RepositoryTreeProps> = ({ onSelect }) => {
@@ -17,22 +19,14 @@ const RepositoryTreeRoot: React.FC<RepositoryTreeProps> = ({ onSelect }) => {
 const RepositoryNode: React.FC<{
   scope: RepoScope
   name: string
-  onSelect?: (scope: RepoScope) => void
+  onSelect?: (repo: RepoListing) => void
   home?: boolean
 }> = ({ scope, name, onSelect, home }) => {
-  const [isOpen, setIsOpen] = useState(true)
   const children = useTree()
-
-  const handleToggle = (e: React.MouseEvent) => {
-    e.stopPropagation()
-    if (children && children.length > 0) {
-      setIsOpen((prev) => !prev)
-    }
-  }
 
   const handleSelect = (e: React.MouseEvent) => {
     e.stopPropagation()
-    onSelect?.(scope)
+    onSelect?.({ name, scope })
   }
 
   return (
@@ -41,17 +35,7 @@ const RepositoryNode: React.FC<{
         className="flex items-center py-1.5 px-2 rounded-md hover:bg-gray-100 cursor-pointer"
         onClick={handleSelect}
       >
-        <div className="w-5 flex-shrink-0" onClick={handleToggle}>
-          {children && children.length > 0 ? (
-            isOpen ? (
-              <ChevronDown size={16} />
-            ) : (
-              <ChevronRight size={16} />
-            )
-          ) : (
-            <span className="w-4" />
-          )}
-        </div>
+        <div className="w-5 flex-shrink-0" />
         <div className="flex items-center flex-1 min-w-0">
           <div className="mr-2 text-gray-500">
             {home ? <Home size={16} /> : <FolderGit2 size={16} />}
@@ -64,9 +48,7 @@ const RepositoryNode: React.FC<{
       </div>
 
       {children && children.length > 0 && (
-        <div
-          className={`pl-4 border-l border-gray-200 ml-2 ${isOpen ? '' : 'hidden'}`}
-        >
+        <div className="pl-4 border-l border-gray-200 ml-2">
           {children.map((child) => (
             <ArtifactSyncer key={child.scope.repo} {...child.scope}>
               <RepositoryNode


### PR DESCRIPTION
## Summary
- keep repo tree permanently expanded and use repo `name` for display
- preserve top-level repo as `home`
- show repo display name, repo id and DID on the repo card
- ensure deselecting resets selection to `home`

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_6852431d094c832bb36b74acc91a9170