### PR TITLE
Improve repository selection and modal behaviour

### DIFF
--- a/src/components/ReposView.tsx
+++ b/src/components/ReposView.tsx
@@ -11,7 +11,11 @@ import { useFrame, useScope } from '@artifact/client/hooks'
 export default function ReposView() {
   const scope = useScope()
   const homeListing = useMemo(
-    () => ({ name: 'home', scope: scope as RepoListing['scope'] }),
+    () => ({
+      name: 'home',
+      scope: scope as RepoListing['scope'],
+      path: ['home']
+    }),
     [scope]
   )
   const [selected, setSelected] = useState<RepoListing | null>(
@@ -76,15 +80,28 @@ export default function ReposView() {
       <div className="bg-white rounded-lg border border-gray-200 p-4">
         <h2 className="text-lg font-medium mb-4">Repository Structure</h2>
         <div className="mt-4">
-          <RepositoryTree onSelect={handleSelect} />
+          <RepositoryTree onSelect={handleSelect} selected={selected} />
         </div>
       </div>
 
-      {showNew && <NewRepositoryModal onClose={() => setShowNew(false)} />}
-      {showClone && (
-        <CloneRepositoryModal onClose={() => setShowClone(false)} />
+      {showNew && selected && (
+        <NewRepositoryModal
+          onClose={() => setShowNew(false)}
+          target={selected}
+        />
       )}
-      {showLink && <LinkRepositoryModal onClose={() => setShowLink(false)} />}
+      {showClone && selected && (
+        <CloneRepositoryModal
+          onClose={() => setShowClone(false)}
+          target={selected}
+        />
+      )}
+      {showLink && selected && (
+        <LinkRepositoryModal
+          onClose={() => setShowLink(false)}
+          target={selected}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/modals/CloneRepositoryModal.tsx
+++ b/src/components/modals/CloneRepositoryModal.tsx
@@ -2,12 +2,14 @@ import { useState } from 'react'
 import { X, Loader } from 'lucide-react'
 import { useArtifact } from '@artifact/client/hooks'
 import useViewportSize from '../../hooks/useViewportSize'
+import type { RepoListing } from '../RepositoryTree'
 
 interface Props {
   onClose: () => void
+  target: RepoListing
 }
 
-const CloneRepositoryModal: React.FC<Props> = ({ onClose }) => {
+const CloneRepositoryModal: React.FC<Props> = ({ onClose, target }) => {
   const [url, setUrl] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const artifact = useArtifact()
@@ -19,7 +21,8 @@ const CloneRepositoryModal: React.FC<Props> = ({ onClose }) => {
     try {
       const parts = url.trim().split('/')
       const name = parts[parts.length - 1].replace('.git', '')
-      await artifact.tree.clone(name, { name: 'origin', url })
+      const repo = artifact.checkout(target.scope)
+      await repo.tree.clone(name, { name: 'origin', url })
       onClose()
     } catch (err) {
       console.error(err)
@@ -52,6 +55,9 @@ const CloneRepositoryModal: React.FC<Props> = ({ onClose }) => {
             </button>
           )}
         </div>
+        <p className="text-sm text-gray-600 mb-4">
+          Target: {target.path.join(' / ')}
+        </p>
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
             Repository URL*

--- a/src/components/modals/LinkRepositoryModal.tsx
+++ b/src/components/modals/LinkRepositoryModal.tsx
@@ -2,12 +2,14 @@ import { useState } from 'react'
 import { X, Loader } from 'lucide-react'
 import { useArtifact } from '@artifact/client/hooks'
 import useViewportSize from '../../hooks/useViewportSize'
+import type { RepoListing } from '../RepositoryTree'
 
 interface Props {
   onClose: () => void
+  target: RepoListing
 }
 
-const LinkRepositoryModal: React.FC<Props> = ({ onClose }) => {
+const LinkRepositoryModal: React.FC<Props> = ({ onClose, target }) => {
   const [name, setName] = useState('')
   const [url, setUrl] = useState('')
   const [isLoading, setIsLoading] = useState(false)
@@ -18,7 +20,8 @@ const LinkRepositoryModal: React.FC<Props> = ({ onClose }) => {
     if (!name.trim() || !artifact) return
     setIsLoading(true)
     try {
-      await artifact.tree.clone(name.trim(), { name: 'origin', url })
+      const repo = artifact.checkout(target.scope)
+      await repo.tree.clone(name.trim(), { name: 'origin', url })
       onClose()
     } catch (err) {
       console.error(err)
@@ -51,6 +54,9 @@ const LinkRepositoryModal: React.FC<Props> = ({ onClose }) => {
             </button>
           )}
         </div>
+        <p className="text-sm text-gray-600 mb-4">
+          Target: {target.path.join(' / ')}
+        </p>
         <div className="space-y-4">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">

--- a/src/components/modals/NewRepositoryModal.tsx
+++ b/src/components/modals/NewRepositoryModal.tsx
@@ -1,13 +1,15 @@
 import React, { useState } from 'react'
 import { X, Loader } from 'lucide-react'
 import { useArtifact } from '@artifact/client/hooks'
+import type { RepoListing } from '../RepositoryTree'
 import useViewportSize from '../../hooks/useViewportSize'
 
 interface Props {
   onClose: () => void
+  target: RepoListing
 }
 
-const NewRepositoryModal: React.FC<Props> = ({ onClose }) => {
+const NewRepositoryModal: React.FC<Props> = ({ onClose, target }) => {
   const [name, setName] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const artifact = useArtifact()
@@ -17,7 +19,8 @@ const NewRepositoryModal: React.FC<Props> = ({ onClose }) => {
     if (!name.trim() || !artifact) return
     setIsLoading(true)
     try {
-      await artifact.tree.init(name.trim())
+      const repo = artifact.checkout(target.scope)
+      await repo.tree.init(name.trim())
       onClose()
     } catch (err) {
       console.error(err)
@@ -50,6 +53,10 @@ const NewRepositoryModal: React.FC<Props> = ({ onClose }) => {
             </button>
           )}
         </div>
+
+        <p className="text-sm text-gray-600 mb-4">
+          Target: {target.path.join(' / ')}
+        </p>
 
         <div className="space-y-4">
           <div>


### PR DESCRIPTION
## Summary
- highlight the current repository selection in the tree
- toggle to home when clicking a selected repo
- show friendly path and target the selected repo inside all modals

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_685cc1806f50832bb8e798873cccd5b0