### PR TITLE
Fix repo tree resetting

### DIFF
--- a/src/components/RepositoryTree.tsx
+++ b/src/components/RepositoryTree.tsx
@@ -19,6 +19,7 @@ const RepositoryTreeRoot: React.FC<RepositoryTreeProps> = ({
   if (!target || !isRepoScope(target)) return <div>Loading repositories...</div>
   return (
     <RepositoryNode
+      key={target.repo}
       scope={target}
       name={'home'}
       path={['home']}


### PR DESCRIPTION
## Summary
- ensure repo tree node remounts when repository changes to avoid stale children

## Testing
- `npm run ok`


------
https://chatgpt.com/codex/tasks/task_e_685e1162f8a4832b983ab3063d7dba78